### PR TITLE
Add Morphic Monet into Squeak's 'apps' menu

### DIFF
--- a/packages/SketchMorph2-Core.package/MorphicMonet.class/class/addToWorldMenu.st
+++ b/packages/SketchMorph2-Core.package/MorphicMonet.class/class/addToWorldMenu.st
@@ -1,3 +1,3 @@
 class initialization
-initialize
+addToWorldMenu
 	TheWorldMenu registerOpenCommand: {'Morphic Monet'. {self. #open}}

--- a/packages/SketchMorph2-Core.package/MorphicMonet.class/class/initialize.st
+++ b/packages/SketchMorph2-Core.package/MorphicMonet.class/class/initialize.st
@@ -1,0 +1,3 @@
+class initialization
+initialize
+	TheWorldMenu registerOpenCommand: {'Morphic Monet'. {self. #open}}

--- a/packages/SketchMorph2-Core.package/MorphicMonet.class/class/open.st
+++ b/packages/SketchMorph2-Core.package/MorphicMonet.class/class/open.st
@@ -1,3 +1,4 @@
 instance creation
 open
+	MorphicMonet initialize.
 	^ self new openInWorld

--- a/packages/SketchMorph2-Core.package/MorphicMonet.class/class/open.st
+++ b/packages/SketchMorph2-Core.package/MorphicMonet.class/class/open.st
@@ -1,4 +1,4 @@
 instance creation
 open
-	MorphicMonet addToWorldMenu.
+	self addToWorldMenu.
 	^ self new openInWorld

--- a/packages/SketchMorph2-Core.package/MorphicMonet.class/class/open.st
+++ b/packages/SketchMorph2-Core.package/MorphicMonet.class/class/open.st
@@ -1,4 +1,4 @@
 instance creation
 open
-	MorphicMonet initialize.
+	MorphicMonet addToWorldMenu.
 	^ self new openInWorld

--- a/packages/SketchMorph2-Core.package/MorphicMonet.class/methodProperties.json
+++ b/packages/SketchMorph2-Core.package/MorphicMonet.class/methodProperties.json
@@ -1,9 +1,10 @@
 {
 	"class" : {
+		"initialize" : "K.P. 5/21/2021 23:48",
+		"open" : "K.P. 5/21/2021 23:48"
 		"borderColor" : "K.P. 5/29/2021 14:14",
 		"borderWidth" : "mFr 5/26/2021 12:11",
 		"canvasPanelBorder" : "mFr 5/26/2021 12:00",
-		"open" : "mFr 5/19/2021 10:56",
 		"topPanelHeight" : "mFr 5/26/2021 12:02" },
 	"instance" : {
 		"activateDefaultItem" : "mFr 5/19/2021 11:03",

--- a/packages/SketchMorph2-Core.package/MorphicMonet.class/methodProperties.json
+++ b/packages/SketchMorph2-Core.package/MorphicMonet.class/methodProperties.json
@@ -1,7 +1,8 @@
 {
 	"class" : {
+		"addToWorldMenu" : "K.P. 5/27/2021 11:21",
+		"open" : "K.P. 5/27/2021 11:22",
 		"initialize" : "K.P. 5/21/2021 23:48",
-		"open" : "K.P. 5/21/2021 23:48"
 		"borderColor" : "K.P. 5/29/2021 14:14",
 		"borderWidth" : "mFr 5/26/2021 12:11",
 		"canvasPanelBorder" : "mFr 5/26/2021 12:00",


### PR DESCRIPTION
Should close #8. 
Once MorhicMonet is opened by `MorphicMonet open` it will be automatically integrated into the 'apps' menu.