### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:
@@ -16,8 +16,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:
-          smalltalk-version: ${{ matrix.smalltalk }}
+          smalltalk-image: ${{ matrix.smalltalk }}
       - run: smalltalkci -s ${{ matrix.smalltalk }}
+        shell: bash
         timeout-minutes: 15
         env:
           # for uploading coverage reports


### PR DESCRIPTION
Since Windows CI runs don't actually work (the output of the CI is empty, and the CI "passes" when tests are known to fail (e.g. [here](https://github.com/hpi-swa-teaching/SketchMorph2/pull/64/checks?check_run_id=2705528009))), I thought it would be good to remove them from running the CI.