### PR TITLE
Display coverage badge of dev branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![CI](https://github.com/hpi-swa-teaching/SketchMorph2/workflows/CI/badge.svg?branch=dev)
-[![Coverage Status](https://coveralls.io/repos/github/hpi-swa-teaching/SketchMorph2/badge.svg?branch=coverage)](https://coveralls.io/github/hpi-swa-teaching/SketchMorph2?branch=coverage)
+[![Coverage Status](https://coveralls.io/repos/github/hpi-swa-teaching/SketchMorph2/badge.svg?branch=dev)](https://coveralls.io/github/hpi-swa-teaching/SketchMorph2?branch=dev)
 
 # SketchMorph2
 Sketching tool for Squeak. Offers a flexible backend through image form manipulation and friendly usage with a Morphic frontend.


### PR DESCRIPTION
Currently, the badge for branch `coverage` is displayed. It looks like a good idea to me to change this to branch `dev`.